### PR TITLE
feature: add support for passive event listeners

### DIFF
--- a/_config.json
+++ b/_config.json
@@ -20,7 +20,8 @@
 			"src/js/owl.autoplay.js",
 			"src/js/owl.navigation.js",
 			"src/js/owl.hash.js",
-			"src/js/owl.support.js"
+			"src/js/owl.support.js",
+			"src/js/owl.support.jquery.js"
 		]
 	},
 

--- a/src/js/owl.autoplay.js
+++ b/src/js/owl.autoplay.js
@@ -78,12 +78,12 @@
 					this.play();
 				}
 			}, this),
-			'touchstart.owl.core': $.proxy(function() {
+			'touchstart.owl.core.noPreventDefault': $.proxy(function() {
 				if (this._core.settings.autoplayHoverPause && this._core.is('rotating')) {
 					this.pause();
 				}
 			}, this),
-			'touchend.owl.core': $.proxy(function() {
+			'touchend.owl.core.noPreventDefault': $.proxy(function() {
 				if (this._core.settings.autoplayHoverPause) {
 					this.play();
 				}

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -683,8 +683,8 @@
 		}
 
 		if (this.settings.touchDrag){
-			this.$stage.on('touchstart.owl.core', $.proxy(this.onDragStart, this));
-			this.$stage.on('touchcancel.owl.core', $.proxy(this.onDragEnd, this));
+			this.$stage.on('touchstart.owl.core.noPreventDefault', $.proxy(this.onDragStart, this));
+			this.$stage.on('touchcancel.owl.core.noPreventDefault', $.proxy(this.onDragEnd, this));
 		}
 	};
 
@@ -733,7 +733,7 @@
 		this._drag.stage.current = stage;
 		this._drag.pointer = this.pointer(event);
 
-		$(document).on('mouseup.owl.core touchend.owl.core', $.proxy(this.onDragEnd, this));
+		$(document).on('mouseup.owl.core touchend.owl.core.noPreventDefault', $.proxy(this.onDragEnd, this));
 
 		$(document).one('mousemove.owl.core touchmove.owl.core', $.proxy(function(event) {
 			var delta = this.difference(this._drag.pointer, this.pointer(event));

--- a/src/js/owl.support.jquery.js
+++ b/src/js/owl.support.jquery.js
@@ -1,0 +1,34 @@
+/**
+ * jQuery Support Plugin
+ *
+ * @version 1.0.0
+ * @author Christian Hain
+ * @license The MIT License (MIT)
+ */
+;(function($, window, document, undefined) {
+	var eventListenerTypes = [
+		'mousewheel',
+		'touchcancel',
+		'touchdrag',
+		'touchend',
+		'touchstart'
+	],
+	i = 0;
+
+	for (i = 0; i < eventListenerTypes.length; i++) {
+		createSpecialEvent(eventListenerTypes[i]);
+	}
+
+	function createSpecialEvent(eventListenerType) {
+		$.event.special[eventListenerType] = {
+			setup: function(data, namespaces, eventHandle) {
+				if (namespaces.includes('noPreventDefault')) {
+					this.addEventListener(eventListenerType, eventHandle, { passive: true });
+				} else {
+					return false;
+				}
+			}
+		}
+	}
+
+})(window.Zepto || window.jQuery, window, document);


### PR DESCRIPTION
Enable a jQuery event listener name space to use passive event listeners on touch and mousewheel events. Passing `.noPreventDefault` to these events will prevent the listeners from blocking page scroll for a performance benefit.

At the time of this commit, Chrome and Opera provide support for these listeners. This is the status of the spec: https://www.chromestatus.com/feature/5745543795965952

This solution comes from an idea posted by jQuery Foundation Member, Dave Methvin (https://github.com/dmethvin), as a possibility to enable passive event listeners until jQuery decides to how to handle future standards. This is the github issue: https://github.com/jquery/PEP/issues/278

See the blog posts:
* http://blog.chromium.org/2016/05/new-apis-to-help-developers-improve.html
* https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md

# How to test
1. Use Chrome Beta for Android
2. Enable "Show scrolling perf issues" in the Rendering pane  
    * Observe the difference in the number of yellow boxes on the page, indicating performance issues have been addressed
    * If you check this on Chrome for desktop, the boxes will be teal and you won't be able to verify the next step  

    | Enable Show scrolling perf issues | "Broken" | Fixed |
    |------|---------|-----------|
    | ![scrolling perf](https://cloud.githubusercontent.com/assets/910645/15100337/e7ceaf92-153c-11e6-9b77-aa08c6984a72.png) | ![broken](https://cloud.githubusercontent.com/assets/910645/15100355/41d73752-153d-11e6-95f5-fa56de69db31.gif) | ![fixed](https://cloud.githubusercontent.com/assets/910645/15100251/c1813ba4-153a-11e6-8a12-f6bcdeb73fb2.gif) |

3. Verify that event listeners are passive, and not blocking
    1. Inspect a carousel item that has a touch event added to it, such as `.owl-item`
    2. View the event listeners on the element
    3. Filter for Passive listeners, or scroll to find a `touchstart` listener
    4. Expand it and verify that `passive` equals `true`  
    ![passive true](https://cloud.githubusercontent.com/assets/910645/15100363/a1893db2-153d-11e6-8b0f-821fb2ca9b55.png)


# Note
This commit does not check in files for the `dist` directory.