### PR TITLE
fix: protect passive event listeners from IE erroring

### DIFF
--- a/src/js/owl.support.jquery.js
+++ b/src/js/owl.support.jquery.js
@@ -21,10 +21,14 @@
 
 	function createSpecialEvent(eventListenerType) {
 		$.event.special[eventListenerType] = {
-			setup: function(data, namespaces, eventHandle) {
-				if (namespaces.includes('noPreventDefault')) {
-					this.addEventListener(eventListenerType, eventHandle, { passive: true });
-				} else {
+			setup: function(_, ns, handle) {
+				try {
+					if (ns.includes('noPreventDefault')) {
+						this.addEventListener(eventListenerType, handle, { passive: true });
+					} else {
+						return false;
+					}
+				} catch(e) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Put the function that checks if a namespace includes 'noPreventDefault' into a try/catch block. This protects against an Internet Explorer error if `ns` doesn't support `includes`.