### PR TITLE
fix: predefine try variables

### DIFF
--- a/src/js/owl.support.jquery.js
+++ b/src/js/owl.support.jquery.js
@@ -14,7 +14,9 @@
 			'touchend',
 			'touchstart'
 		],
-		i = 0;
+		i = 0,
+		opts = null,
+		testEvents = null;
 
 	try {
 		// Check to see if the browser can create new Events this way.


### PR DESCRIPTION
The try/catch for adding event listener options are failing because the variables are not previously defined.