### PR TITLE
[feature/CNN-27675]  Fixing the slide direction when the visible slides are more then half of slides

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -1179,9 +1179,6 @@
 			maximum = this.maximum();
 
 		if (this.settings.loop) {
-			if (!this.settings.rewind && Math.abs(distance) > items / 2) {
-				distance += direction * -1 * items;
-			}
 
 			position = current + distance;
 			revert = ((position - minimum) % items + items) % items + minimum;


### PR DESCRIPTION
https://jiraprod.turner.com/browse/CNN-27675

Fixing the slide direction when the visible slides are more then half of slides

This is tested in local michonne and is working as expected.

Github reference: https://github.com/OwlCarousel2/OwlCarousel2/issues/984#issuecomment-352623055